### PR TITLE
swap ws out with wss

### DIFF
--- a/ucp/assets/jssiplibs/jssip-0.7.23.js
+++ b/ucp/assets/jssiplibs/jssip-0.7.23.js
@@ -20426,7 +20426,7 @@ UA.prototype.loadConfig = function(configuration) {
   this.contact = {
     pub_gruu: null,
     temp_gruu: null,
-    uri: new URI('sip', Utils.createRandomToken(8), settings.via_host, null, {transport: 'ws'}),
+    uri: new URI('sip', Utils.createRandomToken(8), settings.via_host, null, {transport: 'wss'}),
     toString: function(options) {
       options = options || {};
 

--- a/ucp/assets/jssiplibs/jssip-0.7.23.js
+++ b/ucp/assets/jssiplibs/jssip-0.7.23.js
@@ -20426,7 +20426,7 @@ UA.prototype.loadConfig = function(configuration) {
   this.contact = {
     pub_gruu: null,
     temp_gruu: null,
-    uri: new URI('sip', Utils.createRandomToken(8), settings.via_host, null, {transport: 'wss'}),
+    uri: new URI('sip', Utils.createRandomToken(8), settings.via_host, null, {transport: 'ws'}),
     toString: function(options) {
       options = options || {};
 


### PR DESCRIPTION
see detailed conversation here: http://community.freepbx.org/t/webrtc-support/33687/29

asterisk has a bug: https://issues.asterisk.org/jira/browse/ASTERISK-24330
which forces us to hack the RFC spec until it is resolved, since FreePBX only connects the UCP to asterisk and WebRTC is usless over http, this hack should be in place until Asterisk can patch, then this change will need some more work to handle unpatched and patched versions of asterisk